### PR TITLE
Skip migration on rows where the source doesn't have an etag

### DIFF
--- a/src/main/java/org/sagebionetworks/migration/delta/RangeDeltaBuilder.java
+++ b/src/main/java/org/sagebionetworks/migration/delta/RangeDeltaBuilder.java
@@ -116,14 +116,8 @@ public class RangeDeltaBuilder {
 			if (sourceId == destId) {
 				// Is either null?
 				if (sourceRow != null && destRow != null) {
-					// Null etag check
-					if (sourceRow.getEtag() == null) {
-						if (destRow.getEtag() != null) {
-							toUpdate.write(sourceRow);
-							updateCount++;
-						}
-					} else {
-						// Etags are not null so are they equal?
+					if (sourceRow.getEtag() != null) {
+					    // If source row has an etag column, compare etags; otherwise skip this row.
 						if (!sourceRow.getEtag().equals(destRow.getEtag())) {
 							toUpdate.write(sourceRow);
 							updateCount++;

--- a/src/main/java/org/sagebionetworks/migration/delta/RangeDeltaBuilder.java
+++ b/src/main/java/org/sagebionetworks/migration/delta/RangeDeltaBuilder.java
@@ -117,7 +117,7 @@ public class RangeDeltaBuilder {
 				// Is either null?
 				if (sourceRow != null && destRow != null) {
 					if (sourceRow.getEtag() != null) {
-					    // If source row has an etag column, compare etags; otherwise skip this row.
+						// If source row has an etag column, compare etags; otherwise skip this row.
 						if (!sourceRow.getEtag().equals(destRow.getEtag())) {
 							toUpdate.write(sourceRow);
 							updateCount++;


### PR DESCRIPTION
Do not merge until we have made sure that every table in production has non nullable etag columns.