### PR TITLE
If no common rows, migrate full source and delete destination

### DIFF
--- a/src/main/java/org/sagebionetworks/migration/async/MissingFromDestinationIterator.java
+++ b/src/main/java/org/sagebionetworks/migration/async/MissingFromDestinationIterator.java
@@ -44,11 +44,6 @@ public class MissingFromDestinationIterator implements Iterator<DestinationJob> 
 		long desMaxId = (typeToMigrate.getDestMaxId() != null) ? typeToMigrate.getDestMaxId() : 0L;
 		long desCount = (typeToMigrate.getDestCount() != null) ? typeToMigrate.getDestCount() : 0L;
 
-		if (desCount < config.getDestinationRowCountToIgnore()) {
-			// treat the destination as empty
-			desMaxId = desMinId;
-		}
-
 		// If the source is empty we need to delete everything from the destination
 		if (typeToMigrate.getSrcMinId() == null) {
 			srcMinId = desMinId;
@@ -56,6 +51,8 @@ public class MissingFromDestinationIterator implements Iterator<DestinationJob> 
 			// No rows in common, the destination needs to be deleted
 			minCommonId = 0L;
 			maxCommonId = 0L;
+			absoluteMinId = 0L;
+			absoluteMaxId = desMaxId;
 		} else {
 			srcMinId = typeToMigrate.getSrcMinId();
 			srcMaxId = typeToMigrate.getSrcMaxId();
@@ -76,7 +73,7 @@ public class MissingFromDestinationIterator implements Iterator<DestinationJob> 
 			if (maxCommonId <= minCommonId) {
 				// no rows common between the source and destination so a full backup of the source is required.
 				long minimumId = srcMinId;
-				long maximumId = srcMaxId + 1;
+				long maximumId = absoluteMaxId + 1;
 				Iterator<DestinationJob> iterator = backupJobExecutor.executeBackupJob(migrationType, minimumId,
 						maximumId);
 				jobIterator = Iterators.concat(jobIterator, iterator);

--- a/src/main/java/org/sagebionetworks/migration/config/Configuration.java
+++ b/src/main/java/org/sagebionetworks/migration/config/Configuration.java
@@ -80,13 +80,6 @@ public interface Configuration {
 	public long getDelayBeforeMigrationStartMS();
 	
 	/**
-	 * If the destination row count is less than this number, the destination table will be treated
-	 * as empty and a full backup/restore for that type will occur.
-	 * @return
-	 */
-	public long getDestinationRowCountToIgnore();
-	
-	/**
 	 * Should the destination stack remain in read-only mode after successful migration?
 	 * @return By default returns false.  Override 
 	 */

--- a/src/main/java/org/sagebionetworks/migration/config/MigrationConfigurationImpl.java
+++ b/src/main/java/org/sagebionetworks/migration/config/MigrationConfigurationImpl.java
@@ -20,7 +20,6 @@ import com.google.inject.Inject;
 public class MigrationConfigurationImpl implements Configuration {
 
 	static final String KEY_REMAIN_READ_ONLY_MODE = "org.sagebionerworks.remain.read.only.mode";
-	static final String KEY_DESTINATION_ROW_COUNT_TO_IGNORE = "org.sagebiontworks.destination.row.count.to.ignore";
 	static final String KEY_SOURCE_REPOSITORY_ENDPOINT = "org.sagebionetworks.source.repository.endpoint";
 	static final String KEY_SOURCE_AUTHENTICATION_ENDPOINT = "org.sagebionetworks.source.authentication.endpoint";
 	static final String KEY_DESTINATION_REPOSITORY_ENDPOINT = "org.sagebionetworks.destination.repository.endpoint";
@@ -156,11 +155,6 @@ public class MigrationConfigurationImpl implements Configuration {
 	}
 	
 	@Override
-	public long getDestinationRowCountToIgnore() {
-		return Long.parseLong(getProperty(KEY_DESTINATION_ROW_COUNT_TO_IGNORE));
-	}
-
-	@Override
 	public void logConfiguration() {
 		logger.info("Source: "+getSourceConnectionInfo().toString());
 		logger.info("Destination: "+getDestinationConnectionInfo().toString());
@@ -170,7 +164,6 @@ public class MigrationConfigurationImpl implements Configuration {
 		logger.info("Include full table checksums: "+includeFullTableChecksums());
 		logger.info("Asynchronous job timeout MS: "+getWorkerTimeoutMs());
 		logger.info("Delay before migration starts MS: "+getDelayBeforeMigrationStartMS());
-		logger.info("Destination row count to ignore: "+getDestinationRowCountToIgnore());
 	}
 	
 	/**

--- a/src/test/java/org/sagebionetworks/migration/async/MissingFromDestinationIteratorTest.java
+++ b/src/test/java/org/sagebionetworks/migration/async/MissingFromDestinationIteratorTest.java
@@ -37,7 +37,6 @@ public class MissingFromDestinationIteratorTest {
 	int batchSize;
 	String backupFileKey;
 	BackupAliasType aliasType;
-	long destinationRowCountToIgnore;
 	RestoreDestinationJob one;
 	RestoreDestinationJob two;
 	
@@ -45,7 +44,6 @@ public class MissingFromDestinationIteratorTest {
 	public void before() {
 		type = MigrationType.NODE;
 		batchSize = 3;
-		destinationRowCountToIgnore = 10;
 		when(mockConfig.getMaximumBackupBatchSize()).thenReturn(batchSize);
 		aliasType = BackupAliasType.TABLE_NAME;
 		when(mockConfig.getBackupAliasType()).thenReturn(aliasType);
@@ -103,7 +101,7 @@ public class MissingFromDestinationIteratorTest {
 	}
 	
 	@Test
-	public void testSouceMinNull() {
+	public void testSourceMinNull() {
 		TypeToMigrateMetadata ranges = new TypeToMigrateMetadata();
 		ranges.setType(type);
 		ranges.setSrcMinId(null);

--- a/src/test/java/org/sagebionetworks/migration/async/MissingFromDestinationIteratorTest.java
+++ b/src/test/java/org/sagebionetworks/migration/async/MissingFromDestinationIteratorTest.java
@@ -46,7 +46,6 @@ public class MissingFromDestinationIteratorTest {
 		type = MigrationType.NODE;
 		batchSize = 3;
 		destinationRowCountToIgnore = 10;
-		when(mockConfig.getDestinationRowCountToIgnore()).thenReturn(destinationRowCountToIgnore);
 		when(mockConfig.getMaximumBackupBatchSize()).thenReturn(batchSize);
 		aliasType = BackupAliasType.TABLE_NAME;
 		when(mockConfig.getBackupAliasType()).thenReturn(aliasType);
@@ -81,31 +80,6 @@ public class MissingFromDestinationIteratorTest {
 		// nothing to do.
 		assertFalse(iterator.hasNext());
 		verifyZeroInteractions(mockBackupJobExecutor);
-	}
-	
-	/**
-	 * Treat the destination as empty when there are only a few rows
-	 * in the destination.
-	 */
-	@Test
-	public void testDestinationCountLessThanIgnore() {
-		TypeToMigrateMetadata ranges = new TypeToMigrateMetadata();
-		ranges.setType(type);
-		ranges.setSrcMinId(1L);
-		ranges.setSrcMaxId(99L);
-		ranges.setSrcCount(98L);
-		ranges.setDestMinId(1L);
-		ranges.setDestMaxId(99L);
-		ranges.setDestCount(destinationRowCountToIgnore-1);
-		
-		MissingFromDestinationIterator iterator = new MissingFromDestinationIterator(mockConfig, mockBackupJobExecutor, ranges);
-		assertTrue(iterator.hasNext());
-		assertEquals(one, iterator.next());
-		assertFalse(iterator.hasNext());
-		
-		// should backup the full range for this case
-		verify(mockBackupJobExecutor).executeBackupJob(type, 1L, 100L);
-		verify(mockBackupJobExecutor, times(1)).executeBackupJob(any(MigrationType.class), anyLong(), anyLong());
 	}
 	
 	@Test
@@ -145,9 +119,6 @@ public class MissingFromDestinationIteratorTest {
 		it.hasNext();
 
 		verify(mockBackupJobExecutor).executeBackupJob(type, 1L, 100L);
-
-
-
 	}
 	
 	@Test
@@ -253,6 +224,24 @@ public class MissingFromDestinationIteratorTest {
 		verify(mockBackupJobExecutor).executeBackupJob(type, 1L, 26L);
 		verify(mockBackupJobExecutor).executeBackupJob(type, 51L, 100L);
 		verify(mockBackupJobExecutor, times(2)).executeBackupJob(any(MigrationType.class), anyLong(), anyLong());
+	}
+
+	@Test
+	public void testSourceMaxLessThanOrEqualDestinationMin() {
+		TypeToMigrateMetadata ranges = new TypeToMigrateMetadata();
+		ranges.setType(type);
+		ranges.setSrcMinId(1L);
+		ranges.setSrcMaxId(1L);
+		ranges.setSrcCount(1L);
+		ranges.setDestMinId(1L);
+		ranges.setDestMaxId(8L);
+		ranges.setDestCount(5L);
+
+		MissingFromDestinationIterator iterator = new MissingFromDestinationIterator(mockConfig, mockBackupJobExecutor, ranges);
+
+		assertTrue(iterator.hasNext());
+
+		verify(mockBackupJobExecutor).executeBackupJob(type, 1L, 9L);
 	}
 
 }

--- a/src/test/java/org/sagebionetworks/migration/config/MigrationConfigurationImplTest.java
+++ b/src/test/java/org/sagebionetworks/migration/config/MigrationConfigurationImplTest.java
@@ -87,8 +87,7 @@ public class MigrationConfigurationImplTest {
 		props.put(MigrationConfigurationImpl.KEY_INCLUDE_FULL_TABLE_CHECKSUM, "true");
 		props.put(MigrationConfigurationImpl.KEY_DELAY_BEFORE_START_MS, "30000");
 		props.put(MigrationConfigurationImpl.KEY_THREAD_TIMOUT_MS, "100000000");
-		props.put(MigrationConfigurationImpl.KEY_DESTINATION_ROW_COUNT_TO_IGNORE, "1000");
-		
+
 		when(mockPropertyProvider.getSystemProperties()).thenReturn(props);
 		when(mockPropertyProvider.createNewProperties()).thenReturn(mockProperties);
 
@@ -148,7 +147,7 @@ public class MigrationConfigurationImplTest {
 	public void testLogConfiguration() {
 		// call under test
 		config.logConfiguration();
-		verify(mockLogger, times(9)).info(anyString());
+		verify(mockLogger, times(8)).info(anyString());
 	}
 	
 	@Test


### PR DESCRIPTION
PFLM-5865: If disjoints set of ids, migrate all source but also delete all destination.