### PR TITLE
PLFM-9151: Add rolling files logger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<log4j.version>2.17.1</log4j.version>
 		<commons-logging.version>1.2</commons-logging.version>
-		<synapseclient.version>551.0</synapseclient.version>
+		<synapseclient.version>554.0-2-gb427155156</synapseclient.version>
 		<junit.version>4.13.1</junit.version>
 		<awssdk.version>1.12.15</awssdk.version>
 		<mockito.version>1.10.19</mockito.version>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -13,7 +13,7 @@
                      createOnDemand="true">
             <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%t] %c - %m%n"/>
             <Policies>
-                <SizeBasedTriggeringPolicy size="10KB"/>
+                <SizeBasedTriggeringPolicy size="2MB"/>
             </Policies>
             <DefaultRolloverStrategy max="10"/>
         </RollingFile>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,13 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-	<appenders>
-		<console name="console" target="SYSTEM_OUT">
-			<PatternLayout pattern="%d{HH:mm:ss,SSS} %-5p - %m%n" />
-		</console>
-	</appenders>
-	<loggers>
-		<root level="INFO">
-			<appender-ref ref="console"/>"
-		</root>
-	</loggers>
+    <properties>
+        <property name="LOG_DIR">${sys:user.dir}/logs</property>
+    </properties>
+    <appenders>
+        <Console name="ConsoleAppender">
+            <PatternLayout pattern="%d{HH:mm:ss,SSS} %-5p [%t] %c - %m%n" />
+        </Console>
+        <RollingFile name="RollingFileAppender"
+                     fileName="${LOG_DIR}/migration-utility.log"
+                     filePattern="${LOG_DIR}/migration-utility-%i.log.gz"
+                     createOnDemand="true">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%t] %c - %m%n"/>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="10KB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="10"/>
+        </RollingFile>
+    </appenders>
+    <loggers>
+        <root level="INFO">
+            <AppenderRef ref="${sys:log.target:-ConsoleAppender}"/>
+        </root>
+    </loggers>
 </configuration>


### PR DESCRIPTION
The failure in this issue happened after more than 1 day migrating, so the log was truncated.
This PR adds a rolling file appender and the ability to specify which appender to use (default is console).
Also updated dependency on SynapseClient to pick up the fix for PLFM-9129.

Need to add '-Dlog.target=RollingFileAppender' to the maven command in synapse-ops-dev/prod.

